### PR TITLE
BugFix: 로그아웃 후 로그인 시 에러 발생 해결

### DIFF
--- a/src/pages/LoginPage/Login.tsx
+++ b/src/pages/LoginPage/Login.tsx
@@ -19,6 +19,9 @@ function Login() {
   const setUserState = useSetRecoilState(userState)
   const setLoginState = useSetRecoilState(loginState)
 
+
+
+
   const handleButtonClick = async () => {
     signInWithEmailAndPassword(auth, email, password)
       .then(async (userCredential) => {
@@ -27,8 +30,9 @@ function Login() {
         const userId = userCredential.user.uid
         const docRef = doc(db, "user", userId);
         const docSnap = (await getDoc(docRef));
+        const userCopy = JSON.parse(JSON.stringify(user));
         await setUserState({
-          userCredential: user,
+          userCredential: userCopy,
           userData: docSnap.data()
         })
         await setLoginState(true)
@@ -53,7 +57,7 @@ function Login() {
       </LoginInputBox>
       <LoginInputBox>
         <P>비밀번호</P>
-        <LoginInput type="text" value={password} placeholder="비밀번호를 입력하세요" onChange={(e) => setPassword(e.target.value)} />
+        <LoginInput type="password" value={password} placeholder="비밀번호를 입력하세요" onChange={(e) => setPassword(e.target.value)} />
       </LoginInputBox>
       <ButtonBox>
         <SignUpBtn type="button">

--- a/src/pages/MainPage/Main.tsx
+++ b/src/pages/MainPage/Main.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useSetRecoilState } from 'recoil'
+import { signOut } from 'firebase/auth'
+
 import userState from '../../recoil/atoms/userState'
 import loginState from '../../recoil/atoms/loginState'
+import { auth } from '../../firebaseSDK'
 
 export default function Main() {
 
@@ -11,12 +14,15 @@ export default function Main() {
   const setLoginState = useSetRecoilState(loginState)
 
   const handleLogout = async () => {
-    await setUserState({
-      isLogin: false,
-      userInfo: {}
+
+    signOut(auth).then(async () => {
+      await setUserState({
+        isLogin: false,
+        userInfo: {}
+      })
+      await setLoginState(false)
+      navigate("/login")
     })
-    await setLoginState(false)
-    navigate("/login")
   }
 
   return (

--- a/src/styled/LoginPage/Login.ts
+++ b/src/styled/LoginPage/Login.ts
@@ -5,6 +5,13 @@ export const StyledLink = styled(Link)`
   text-decoration: none;
   color: white;
   font-weight: 600;
+
+  display: block;
+  background-color: #96a0ff;
+  border: none;
+  width: 192px;
+  height: 73px;
+  border-radius: 50px;
 `;
 
 export const P = styled.p`


### PR DESCRIPTION
Firebase 의 로그인과 recoil이 서로 충돌하는 문제가 있는 것 같습니다.
정확한 이유는 모르지만, Firebase에서 가져오는 auth 객체가 recoil에 의해 불변객체가 되어버리는 현상이 발생하여
recoil 내부에 해당 객체를 깊은복사를 하여 넣어주었습니다. (더 좋은 방법이 있지만 일단 JSON parse를 이용했습니다.)

하지만 아직 이해하지 못한것은 firebase는 auth.SignOut() 이라는 메소드를 통해 로그아웃을 진행하는데,
어떻게 이 메소드가 제가 깊은복사를 했을 경우 해당 정보에 접근 가능한지 잘 모르겠습니다.

저는 Firebase 에서 유저 정보를 따로 저장하고 로그아웃시에 이를 이용하는 줄 알았는데, 이 방식이 아닌 것 같습니다.